### PR TITLE
Fix core helpers and add unit tests

### DIFF
--- a/src/gbaEmu/CPU.java
+++ b/src/gbaEmu/CPU.java
@@ -101,9 +101,9 @@ public class CPU {
 		case 3:
 			register.pc = 0x58;
 			break;
-		case 4:
-			register.pc = 60;
-			break;
+                case 4:
+                        register.pc = 0x60;
+                        break;
 		default:
 			Log.fatalf("unknown interrupt: " + id);
 		}
@@ -1017,12 +1017,12 @@ public class CPU {
 		register.pc++;
 		return ans;
 	}
-	public short getValue16() {
-		int value1 = memory.readMemory(register.pc);
-		int value2 = memory.readMemory(register.pc + 1);
-		register.pc += 2;
-		return (short) (value1 << 8 + value2);
-	}
+        public short getValue16() {
+                int value1 = memory.readMemory(register.pc) & 0xFF;
+                int value2 = memory.readMemory(register.pc + 1) & 0xFF;
+                register.pc += 2;
+                return (short) ((value1 << 8) | value2);
+        }
 	public int decrementHL() {
 		int hl = register.hl();
 		hl--;

--- a/src/gbaEmu/Memory.java
+++ b/src/gbaEmu/Memory.java
@@ -17,19 +17,19 @@ public class Memory {
 		mainMemory[address]++;
 	}
 	// 16 bit stack push
-	public int stackPush(short value) {
-		cpu.register.sp--;
-		writeMemory(cpu.register.sp, (byte) (value >> 8));
-		cpu.register.sp--;
-		writeMemory(cpu.register.sp, (byte) (value & 0xFF));
-		return 0;
-	}
-	//16 bit stack pop
-	public short stackPop() {
-		cpu.register.sp++;
-		int low = readMemory(cpu.register.sp);
-		cpu.register.sp++;
-		int high = readMemory(cpu.register.sp);
-		return (short) (high << 8 | low);
-	}
+        public int stackPush(short value) {
+                cpu.register.sp--;
+                writeMemory(cpu.register.sp & 0xFFFF, (byte) (value >> 8));
+                cpu.register.sp--;
+                writeMemory(cpu.register.sp & 0xFFFF, (byte) (value & 0xFF));
+                return 0;
+        }
+        //16 bit stack pop
+        public short stackPop() {
+                int low = readMemory(cpu.register.sp & 0xFFFF);
+                cpu.register.sp++;
+                int high = readMemory(cpu.register.sp & 0xFFFF);
+                cpu.register.sp++;
+                return (short) ((high << 8) | (low & 0xFF));
+        }
 }

--- a/src/gbaEmu/Opcodes.java
+++ b/src/gbaEmu/Opcodes.java
@@ -1117,24 +1117,24 @@ public class Opcodes {
 		cpu.putSP(cpu.register.sp - 1);
 		return 0;
 	}
-	public int OPCB() {
-		byte n = cpu.getValue8();
-		if (cpu.opMap.containsKey(0xCB << 2 + n)) {
-			Runnable op = cpu.opMap.get(0xCB << 2 + n);
-			op.run();
-		} else {
-			return -1;
-		}
-		return cpu.opCycles.get(0xCB << 2 + n);
-	}
-	private byte swapByteAndSetFlags(byte a) {
-		byte res = (byte) (((a & 0xF) << 4) | ((a & 0xF0) >> 4));
-		cpu.register.nf = false;
-		cpu.register.hf = false;
-		cpu.register.hf = false;
-		cpu.register.zf = res == 0;
-		return res;
-	}
+        public int OPCB() {
+                byte n = cpu.getValue8();
+                int op = (0xCB << 8) | (n & 0xFF);
+                if (cpu.opMap.containsKey(op)) {
+                        Runnable run = cpu.opMap.get(op);
+                        run.run();
+                        return cpu.opCycles.get(op);
+                }
+                return -1;
+        }
+        private byte swapByteAndSetFlags(byte a) {
+                byte res = (byte) (((a & 0xF) << 4) | ((a & 0xF0) >> 4));
+                cpu.register.nf = false;
+                cpu.register.hf = false;
+                cpu.register.cf = false;
+                cpu.register.zf = res == 0;
+                return res;
+        }
 	public int OPCB37() {
 		cpu.register.a = swapByteAndSetFlags(cpu.register.a);
 		return 0;

--- a/src/gbaEmu/Util.java
+++ b/src/gbaEmu/Util.java
@@ -9,12 +9,11 @@ public final class Util {
 		assert pos >= 0: "testbit parameter must be positive";
 		return (n & (1 << pos)) > 0;
 	}
-	public static byte clearBit(byte n, int pos) {
-		assert pos >= 0: "clearbit parameter must be positive";
-		byte allSetTemplate = (byte) 0xFFFF;
-		byte clearTemplate = (byte) (((byte) (1 << pos)) ^ allSetTemplate);
-		return (byte) (pos & clearTemplate);
-	}
+        public static byte clearBit(byte n, int pos) {
+                assert pos >= 0: "clearbit parameter must be positive";
+                byte clearTemplate = (byte) ~(1 << pos);
+                return (byte) (n & clearTemplate);
+        }
 	public static byte getVal(byte val, int pos) {
 		return (byte) ((val >> pos) & 1);
 	}

--- a/src/gbaEmu/Video.java
+++ b/src/gbaEmu/Video.java
@@ -65,24 +65,28 @@ public class Video {
 					int red = 0;
 					int green = 0;
 					int blue = 0;
-					switch (color) {
-						case 0:
-							red = 255;
-							green = 255;
-							blue = 255;
-						case 1:
-							red = 0xCC;
-							green = 0xCC;
-							blue = 0xCC;
-						case 2:
-							red = 0x77;
-							green = 0x77;
-							blue = 0x77;
-						default:
-							red = 0;
-							green = 0;
-							blue = 0;
-					}
+                                        switch (color) {
+                                                case 0:
+                                                        red = 255;
+                                                        green = 255;
+                                                        blue = 255;
+                                                        break;
+                                                case 1:
+                                                        red = 0xCC;
+                                                        green = 0xCC;
+                                                        blue = 0xCC;
+                                                        break;
+                                                case 2:
+                                                        red = 0x77;
+                                                        green = 0x77;
+                                                        blue = 0x77;
+                                                        break;
+                                                default:
+                                                        red = 0;
+                                                        green = 0;
+                                                        blue = 0;
+                                                        break;
+                                        }
 					int xPix = 0 - tilePixel;
 					xPix *= -1;
 					int pixel = xPos + xPix;
@@ -158,12 +162,12 @@ public class Video {
 			} else {
 				tileNum = (int)(byte)memory.readMemory(tileAddress);
 			}
-			int tileLocation = tileData;
-			if (unSigned) {
-				tileLocation += tileData * 16;
-			} else {
-				tileLocation = tileLocation + (tileNum + 128) * 16;
-			}
+                        int tileLocation;
+                        if (unSigned) {
+                                tileLocation = tileData + tileNum * 16;
+                        } else {
+                                tileLocation = tileData + (tileNum + 128) * 16;
+                        }
 			int line = yPos % 8;
 			line *= 2;
 			byte data1 = memory.readMemory(tileLocation + line);
@@ -179,24 +183,28 @@ public class Video {
 			int red = 0;
 			int green = 0;
 			int blue = 0;
-			switch (color) {
-				case 0:
-					red = 255;
-					green = 255;
-					blue = 255;
-				case 1:
-					red = 0xCC;
-					green = 0xCC;
-					blue = 0xCC;
-				case 2:
-					red = 0x77;
-					green = 0x77;
-					blue = 0x77;
-				default:
-					red = 0;
-					green = 0;
-					blue = 0;
-			}
+                        switch (color) {
+                                case 0:
+                                        red = 255;
+                                        green = 255;
+                                        blue = 255;
+                                        break;
+                                case 1:
+                                        red = 0xCC;
+                                        green = 0xCC;
+                                        blue = 0xCC;
+                                        break;
+                                case 2:
+                                        red = 0x77;
+                                        green = 0x77;
+                                        blue = 0x77;
+                                        break;
+                                default:
+                                        red = 0;
+                                        green = 0;
+                                        blue = 0;
+                                        break;
+                        }
 			int yIndex = memory.readMemory(0xFF44);
 			if (yIndex < 0 || yIndex > 143 || pixel < 0 || pixel > 159) {
 				continue;
@@ -216,39 +224,49 @@ public class Video {
 		byte palette = memory.readMemory(address);
 		int high;
 		int low;
-		switch (colorNum) {
-			case 0:
-				high = 1;
-				low = 0;
-			case 1:
-				high = 3;
-				low = 2;
-			case 2:
-				high = 5;
-				low = 4;
-			case 3:
-				high = 7;
-				low = 6;
-			default:
-				high = 1;
-				low = 0;
-		}
+                switch (colorNum) {
+                        case 0:
+                                high = 1;
+                                low = 0;
+                                break;
+                        case 1:
+                                high = 3;
+                                low = 2;
+                                break;
+                        case 2:
+                                high = 5;
+                                low = 4;
+                                break;
+                        case 3:
+                                high = 7;
+                                low = 6;
+                                break;
+                        default:
+                                high = 1;
+                                low = 0;
+                                break;
+                }
 		byte color = 0;
 		color = (byte) (Util.getVal(palette, high) << 1);
 		color |= Util.getVal(palette, low);
 
-		switch (color) {
-			case 0:
-				res = 0;
-			case 1:
-				res = 1;
-			case 2:
-				res = 2;
-			case 3:
-				res = 3;
-			default:
-				res = 0;
-		}
+                switch (color) {
+                        case 0:
+                                res = 0;
+                                break;
+                        case 1:
+                                res = 1;
+                                break;
+                        case 2:
+                                res = 2;
+                                break;
+                        case 3:
+                                res = 3;
+                                break;
+                        default:
+                                res = 0;
+                                break;
+                }
 		return res;
 	}
 }

--- a/test/MemoryTest.java
+++ b/test/MemoryTest.java
@@ -1,0 +1,20 @@
+package gbaEmu;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import gbaEmu.Memory;
+import gbaEmu.CPU;
+
+public class MemoryTest {
+    @Test
+    public void testStackPushPop() {
+        Memory mem = new Memory();
+        mem.cpu = new CPU(mem); // CPU constructor requires Memory
+        mem.cpu.register.sp = (short)0xFFFE;
+        mem.stackPush((short)0xABCD);
+        assertEquals((short)0xFFFC, mem.cpu.register.sp);
+        short val = mem.stackPop();
+        assertEquals((short)0xABCD, val);
+        assertEquals((short)0xFFFE, mem.cpu.register.sp);
+    }
+}

--- a/test/UtilTest.java
+++ b/test/UtilTest.java
@@ -1,0 +1,16 @@
+package gbaEmu;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import gbaEmu.Util;
+
+public class UtilTest {
+    @Test
+    public void testSetClearBit() {
+        byte b = 0;
+        b = Util.setBit(b, 3);
+        assertTrue(Util.testBit(b, 3));
+        b = Util.clearBit(b, 3);
+        assertFalse(Util.testBit(b, 3));
+    }
+}


### PR DESCRIPTION
## Summary
- correct interrupt jump address in CPU
- fix 16‑bit value fetch
- fix stack push/pop addressing
- fix bit clear utility
- fix tile location and color switch fall‑through in `Video`
- correct swap instruction flags and CB dispatch
- add simple JUnit tests for memory stack and util bits

## Testing
- `javac -cp /usr/share/java/junit4.jar:/usr/share/java/hamcrest-core.jar -d bin @sources.txt`
- `java -cp bin:/usr/share/java/junit4.jar:/usr/share/java/hamcrest-core.jar org.junit.runner.JUnitCore gbaEmu.MemoryTest gbaEmu.UtilTest`

------
https://chatgpt.com/codex/tasks/task_e_6845e6dbda4c8330bf2f70af568e4b7c